### PR TITLE
adding conditional to styling in case filterable = TRUE

### DIFF
--- a/vignettes/examples.Rmd
+++ b/vignettes/examples.Rmd
@@ -1020,11 +1020,15 @@ reactable(
   selection = "multiple",
   defaultSelected = c(1, 3),
   rowClass = JS("function(rowInfo) {
-    return rowInfo.selected ? 'selected' : ''
+    if (rowInfo) {
+      return rowInfo.selected ? 'selected' : ''
+    }
   }"),
   rowStyle = JS("function(rowInfo) {
-    if (rowInfo.selected) {
-      return { backgroundColor: '#eee', boxShadow: 'inset 2px 0 0 0 #ffa62d' }
+    if (rowInfo) {
+      if (rowInfo.selected) {
+        return { backgroundColor: '#eee', boxShadow: 'inset 2px 0 0 0 #ffa62d' }
+      }
     }
   }"),
   borderless = TRUE,


### PR DESCRIPTION
Updating the example for styling a row based on selection. With the current example JS function, the whole table disappears if filterable = TRUE and an invalid entry is typed into the box. It seems to have to do with this JS function. It seems like rowInfo is no longer valid when there are no matching rows. 

Adding these to simple if statements solve the problem. *There may be a better way to do this, but this does work*