### PR TITLE
Supply smarter theming defaults if a {bslib} theme is active

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-Remotes: rstudio/bslib#167
+Remotes: rstudio/bslib

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ BugReports: https://github.com/glin/reactable/issues
 Depends:
     R (>= 3.1)
 Imports:
+    utils,
     digest,
     htmltools,
     htmlwidgets,
@@ -31,8 +32,11 @@ Suggests:
     rmarkdown,
     shiny,
     sparkline,
-    testthat
+    testthat,
+    bslib,
+    sass
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+Remotes: rstudio/bslib#167

--- a/R/bslib.R
+++ b/R/bslib.R
@@ -1,0 +1,134 @@
+supplyBsThemeDefaults <- function(instance) {
+  if (system.file(package = "bslib") == "") {
+    return(instance)
+  }
+  theme <- bslib::bs_current_theme()
+  if (!bslib::is_bs_theme(theme)) {
+    return(instance)
+  }
+  # If a bslib theme is relevant, supply new reactableTheme() defaults
+  # based on the relevant Bootstrap Sass variables
+  themeVars <- getThemeVars(theme)
+  for (x in names(themeVars)) {
+    instance$x$tag$attribs$theme[[x]] <-
+      instance$x$tag$attribs$theme[[x]] %||% themeVars[[x]]
+  }
+  styleVals <- getStyleVals(theme)
+  for (x in names(styleVals)) {
+    vals <- styleVals[[x]]
+    if (isTRUE(is.na(vals))) next # failed to parse Sass rules
+    instance$x$tag$attribs$theme[[x]] <- utils::modifyList(
+      vals, instance$x$tag$attribs$theme[[x]] %||% list()
+    )
+  }
+
+  instance
+}
+
+
+getThemeVars <- function(theme) {
+  map <- if (is_bs3(theme)) bsVariableMap3 else bsVariableMap
+  vars <- bslib::bs_get_variables(theme, as.character(map))
+  vars <- setNames(vars, names(map))
+  vars[!is.na(vars)]
+}
+
+# Map the non-style reactableTheme() settings to main Bootstrap Sass variables
+bsVariableMap <- c(
+  color	= "table-color",
+  borderColor	= "table-border-color",
+  borderWidth	= "table-border-width",
+  stripedColor = "table-accent-bg",
+  highlightColor = "primary",
+  cellPadding	= "table-cell-padding"
+)
+
+bsVariableMap3 <- c(
+  color	= "text-color",
+  borderColor	= "table-border-color",
+  stripedColor = "table-bg-accent",
+  highlightColor = "brand-primary",
+  cellPadding	= "table-cell-padding"
+)
+
+
+getStyleVals <- function(theme) {
+  lapply(bsStyleMap, computeStyles, theme = theme)
+}
+
+computeStyles <- function(x, theme) {
+  # Handle BS3isms (without requiring a different bsStyleMap)
+  if (is_bs3(theme)) {
+    theme <- bslib::bs_add_variables(
+      theme, "input-border-width" = "1px",
+      "pagination-border-width" = "1px",
+      "pagination-border-color" = "$pagination-border",
+      "pagination-hover-border-color" = "$pagination-hover-border",
+      "pagination-active-border-color" = "$pagination-active-border",
+      .where = "declarations"
+    )
+  }
+  # Try to compile the Sass rules. Note that an error could happen
+  # if Bootstrap Sass variables change in future versions.
+  # (In that case, we'll need to update accordingly to support BS5+)
+  prop_string <- paste0(names(x), ":", x, collapse = ";")
+  res <- try(
+    sass::sass_partial(
+      paste0(".fake-selector{", prop_string, "}"),
+      theme, options = sass::sass_options(output_style = "compressed")
+    ),
+    silent = TRUE
+  )
+  if (inherits(res, "try-error")) {
+    warning(
+      "Failed to compute the following Sass rule(s) '", prop_string, "'. ",
+      "{reactable}'s theming defaults may not reflect the {bslib} theme.",
+      call. = FALSE
+    )
+    return(NA)
+  }
+  matches <- regmatches(res, regexec(".fake-selector\\s*\\{(.+)\\}", res))
+  asReactStyle(matches[[1]][2])
+}
+
+bsStyleMap <- list(
+  style = list(
+    fontFamily = "$font-family-base",
+    backgroundColor = "if($table-bg==null or alpha($table-bg)==0, $body-bg, $table-bg)"
+  ),
+  headerStyle = list(
+    fontFamily = "$headings-font-family"
+  ),
+  rowHighlightStyle = list(
+    color = "color-yiq($primary)"
+  ),
+  inputStyle = list(
+    color = "$input-color",
+    backgroundColor = "$input-bg",
+    border = "$input-border-width solid $input-border-color"
+  ),
+  pageButtonStyle = list(
+    color = "$pagination-color",
+    backgroundColor = "$pagination-bg",
+    border = "$pagination-border-width solid $pagination-border-color"
+  ),
+  pageButtonHoverStyle = list(
+    color = "$pagination-hover-color",
+    backgroundColor = "$pagination-hover-bg",
+    border = "$pagination-border-width solid $pagination-hover-border-color"
+  ),
+  pageButtonActiveStyle = list(
+    color = "$pagination-active-color",
+    backgroundColor = "$pagination-active-bg",
+    border = "$pagination-border-width solid $pagination-active-border-color"
+  ),
+  pageButtonCurrentStyle = list(
+    color = "$pagination-active-color",
+    backgroundColor = "$pagination-active-bg",
+    border = "$pagination-border-width solid $pagination-active-border-color"
+  )
+)
+
+is_bs3 <- function(theme) {
+  "3" %in% bslib::theme_version(theme)
+}

--- a/R/bslib.R
+++ b/R/bslib.R
@@ -100,7 +100,7 @@ bsStyleMap <- list(
     fontFamily = "$headings-font-family"
   ),
   rowHighlightStyle = list(
-    color = "color-yiq($primary)"
+    color = "color-contrast($primary)"
   ),
   inputStyle = list(
     color = "$input-color",

--- a/R/reactable.R
+++ b/R/reactable.R
@@ -597,12 +597,15 @@ reactable <- function(data, columns = NULL, columnGroups = NULL,
 
   htmlwidgets::createWidget(
     name = "reactable",
-    reactR::reactMarkup(component),
+    x = reactR::reactMarkup(component),
     width = width,
     height = height,
     package = "reactable",
     dependencies = dependencies,
-    elementId = elementId
+    elementId = elementId,
+    preRenderHook = function(instance) {
+      supplyBsThemeDefaults(instance)
+    }
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -246,3 +246,7 @@ callFunc <- function(func, ...) {
   numArgs <- length(formals(func))
   do.call(func, args[seq_len(numArgs)])
 }
+
+"%||%" <- function(x, y) {
+  if (is.null(x)) y else x
+}


### PR DESCRIPTION
This PR allows `reactable()` to supply smarter `reactableTheme()` defaults when a `{bslib}` theme is active at render time. For example:

```r
library(shiny)
library(reactable)
library(bslib)

theme <- bs_theme(
  bg = "#202123", fg = "#B8BCC2", primary = "#EA80FC",
  base_font = font_google("Grandstander")
)

ui <- fluidPage(
  theme = theme,
  reactableOutput("table")
)

server <- function(input, output, session) {
  output$table <- renderReactable({
    reactable(
      mtcars, searchable = TRUE, 
      resizable = TRUE, filterable = TRUE,
      highlight = TRUE, striped = TRUE, 
      outlined = TRUE, bordered = TRUE, 
      # Can still override theme defaults, if you want 
      #theme = reactableTheme(pageButtonStyle = list(color = "orange"))
    )
  })
}

shinyApp(ui, server)
```

<img width="1040" alt="Screen Shot 2020-11-18 at 3 51 29 PM" src="https://user-images.githubusercontent.com/1365941/99592567-fe779000-29b5-11eb-9491-2778168fcb60.png">

Since the widget calls `bslib::bs_current_theme()` inside it's `preRenderHook`, it'll automatically re-render with new theming defaults whenever the `{bslib}` theme changes via `bslib::bs_themer()` (or more generally, whenever the new `session$setCurrentTheme()` is called). This generally just works as long the `reactable()` passed through `renderReactable()`:

```r
library(shiny)
library(reactable)
library(bslib)

ui <- fluidPage(
  theme = bs_theme(),
  reactableOutput("table")
)

x <- reactable(mtcars)

server <- function(input, output, session) {
  bslib::bs_themer()
  output$table <- renderReactable(x)
}

shinyApp(ui, server)
```


This approach will also generally 'just work' in `{rmarkdown}` (when `{bslib}` is being used to provide Bootstrap CSS) once https://github.com/rstudio/rmarkdown/pull/1706 lands 

Outside of Shiny and R Markdown, this can also work in static HTML sites via global `{bslib}` themes:

```r

library(htmltools)
theme <- bs_theme(bootswatch = "darkly")
old_theme <- bs_global_set(theme)
browsable(tags$body(
  bs_theme_dependencies(bs_global_get()),
  reactable(mtcars)
))
bs_global_set(old_theme)
```

<img width="886" alt="Screen Shot 2020-11-18 at 4 20 39 PM" src="https://user-images.githubusercontent.com/1365941/99595248-046f7000-29ba-11eb-9849-c00cb741c14f.png">
