### PR TITLE
Allow column name to be used in details function for column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ where possible, but note that there are several breaking changes.
   ([#88](https://github.com/glin/reactable/issues/88)).
 * Custom cell click actions can now access the table state using a new `state`
   argument.
+* R render functions for row details now receive an additional argument for
+  the column name (@ksnap28, [#155](https://github.com/glin/reactable/issues/155)).
 
 ### Breaking changes
 

--- a/R/reactable.R
+++ b/R/reactable.R
@@ -506,7 +506,7 @@ reactable <- function(data, columns = NULL, columnGroups = NULL,
     details <- column[["details"]]
     if (is.function(details)) {
       details <- lapply(seq_len(nrow(data)), function(index) {
-        callFunc(details, index)
+        callFunc(details, index, key)
       })
       column$details <- lapply(details, asReactTag)
       addDependencies(column$details)

--- a/vignettes/custom-rendering.Rmd
+++ b/vignettes/custom-rendering.Rmd
@@ -337,12 +337,13 @@ reactable(props, sortable = FALSE, bordered = TRUE, columns = list(
 ## Expandable Row Details
 
 ### R render function
-To add expandable row details, provide an R function with a single argument:
+To add expandable row details, provide an R function with up to 2 optional arguments:
 ```{r, eval=FALSE}
 reactable(
-  details = function(index) {
+  details = function(index, name) {
     # input:
     #   - index, the row index
+    #   - name, the column name (optional)
     #
     # output:
     #   - content to render (e.g. an HTML tag or nested table), or NULL to hide details for the row


### PR DESCRIPTION
Adds the column name as a possible argument to the details function when displaying column details.